### PR TITLE
Fixes issues #4, #6

### DIFF
--- a/adafruit_si5351.py
+++ b/adafruit_si5351.py
@@ -211,7 +211,7 @@ class SI5351:
             susceptible to jitter but allows a larger range of PLL frequencies.
             """
             assert 14 < multiplier < 91
-            assert 0 < denominator < 0xFFFFF  # Prevent divide by zero.
+            assert 0 < denominator <= 0xFFFFF  # Prevent divide by zero.
             assert 0 <= numerator < 0xFFFFF
             multiplier = int(multiplier)
             numerator = int(numerator)
@@ -295,7 +295,7 @@ class SI5351:
 
         @r_divider.setter
         def r_divider(self, divider):
-            assert 0 <= divider <= 6
+            assert 0 <= divider <= 7
             reg_value = self._si5351._read_u8(self._r)
             reg_value &= 0x0F
             divider &= 0x07
@@ -347,7 +347,7 @@ class SI5351:
             accurate but has a wider range of output frequencies.
             """
             assert 3 < divider < 901
-            assert 0 < denominator < 0xFFFFF  # Prevent divide by zero.
+            assert 0 < denominator <= 0xFFFFF  # Prevent divide by zero.
             assert 0 <= numerator < 0xFFFFF
             divider = int(divider)
             numerator = int(numerator)


### PR DESCRIPTION
Addresses open issues #4 and #6 for "adafruit_si5351.py"


line 214: changed 
	assert 0 < denominator < 0xFFFFF
to
	assert 0 < denominator <= 0xFFFFF
because 0xFFFFF = 1048575 is a valid pll fractional denominator 
per AN619, page 3.
Addresses issue #6 opened July 14 by phrogger 



line 298: changed
	assert 0 <= divider <= 6
to
	assert 0 <= divider <= 7
because R_DIV_128 corresponding to index 7 is valid.
Addresses issue #4 opened on Mar 24 by evbaarle 



line 350: changed 
	assert 0 < denominator < 0xFFFFF
to
	assert 0 < denominator <= 0xFFFFF
because 0xFFFFF = 1048575 is a valid output fractional denominator 
per AN619, page 6.
Same bug, different location, as issue #6 opened July 14 by phrogger 



The changes were tested by running CP 4.0.2 on a Feather M4 Express with the
changes in a file "adafruit_si5351.py", and verified to work as expected.

The changes were not built into an ".mpy" file locally and verified.
Considering the changes, the risk is low.
If this is a necessary part of testing before a pull-request is accepted,
reject this pull request, and I will figure out how to do that.

--- Graham / phrogger
