### PR TITLE
Use integer math instead of float math

### DIFF
--- a/adafruit_si5351.py
+++ b/adafruit_si5351.py
@@ -29,8 +29,6 @@ library at: https://github.com/adafruit/Adafruit_Si5351_Library/
 
 * Author(s): Tony DiCola
 """
-import math
-
 from micropython import const
 
 import adafruit_bus_device.i2c_device as i2c_device


### PR DESCRIPTION
This patch replaces floating point arithmetic with integer arithmetic
to improve precision.  It exploits the arbitrary precision integers
that are now available in CircuitPython.  It removes the use of the
math.floor function which has known issues as described at:

https://github.com/adafruit/circuitpython/issues/572

The SI5351._PLL.frequency and SI5351._Clock.frequency properties are
now integers rather than floats. Strictly speaking this is a change
to the existing API, although the way Python transparently converts
between integers and floats most people won't notice.  Feel free to
reject this patch if this is an issue.

Clearly this patch will not work on platforms that do not have arbitrary
precision integers.  It seems like most platforms now have this in
CircuitPython 4, but I'm not close enough to the project to know if this
is the case for all platforms that are still supported in CircuitPython 4
and the policy on the use of such integers in libraries.  Feel free to reject
this patch if this is an issue.

I have tested with a ItsyBitsy M4 Express and the Adafruit si5351a
breakout.