### PR TITLE
Support for inverted clocks

### DIFF
--- a/adafruit_si5351.py
+++ b/adafruit_si5351.py
@@ -449,3 +449,14 @@ class SI5351:
             self._write_u8(_SI5351_REGISTER_3_OUTPUT_ENABLE_CONTROL, 0xFF)
         else:
             self._write_u8(_SI5351_REGISTER_3_OUTPUT_ENABLE_CONTROL, 0x00)
+        self.reset_plls()
+
+    def reset_plls(self):
+        """Reset both PLLs. This is required when the phase between clocks
+        needs to be non-random. 
+
+        See e.g.
+
+            https://groups.io/g/BITX20/topic/si5351a_facts_and_myths/5430607
+        """
+        self._write_u8(_SI5351_REGISTER_177_PLL_RESET, (1 << 7) | (1 << 5))

--- a/adafruit_si5351.py
+++ b/adafruit_si5351.py
@@ -330,15 +330,17 @@ class SI5351:
             control |= pll.clock_control_enabled
             control |= 1 << 6  # Enable integer mode.
             if inverted:
-                control |= 0b00010000 # Bit 4 of the control register = CLKx_INV
+                control |= 0b00010000  # Bit 4 of the control register = CLKx_INV
             else:
-                control &= 0b11101111 # Make sure to turn it off if not inverted            
+                control &= 0b11101111  # Make sure to turn it off if not inverted
             self._si5351._write_u8(self._control, control)
             # Store the PLL and divisor value so frequency can be calculated.
             self._pll = pll
             self._divider = divider
 
-        def configure_fractional(self, pll, divider, numerator, denominator, inverted=False):
+        def configure_fractional(
+            self, pll, divider, numerator, denominator, inverted=False
+        ):
             """Configure the clock output with the specified PLL source
             (should be a PLL instance on the SI5351 class) and specifiec
             fractional divider with numerator/denominator.  Again this is less
@@ -372,9 +374,9 @@ class SI5351:
             # Clock not inverted, powered up
             control |= pll.clock_control_enabled
             if inverted:
-                control |= 0b00010000 # Bit 4 of the control register = CLKx_INV
+                control |= 0b00010000  # Bit 4 of the control register = CLKx_INV
             else:
-                control &= 0b11101111 # Make sure to turn it off if not inverted
+                control &= 0b11101111  # Make sure to turn it off if not inverted
             self._si5351._write_u8(self._control, control)
             # Store the PLL and divisor value so frequency can be calculated.
             self._pll = pll
@@ -454,7 +456,7 @@ class SI5351:
 
     def reset_plls(self):
         """Reset both PLLs. This is required when the phase between clocks
-        needs to be non-random. 
+        needs to be non-random.
 
         See e.g.
 

--- a/adafruit_si5351.py
+++ b/adafruit_si5351.py
@@ -307,7 +307,7 @@ class SI5351:
             self._si5351._write_u8(self._base + 6, (p2 & 0x0000FF00) >> 8)
             self._si5351._write_u8(self._base + 7, (p2 & 0x000000FF))
 
-        def configure_integer(self, pll, divider):
+        def configure_integer(self, pll, divider, inverted=False):
             """Configure the clock output with the specified PLL source
             (should be a PLL instance on the SI5351 class) and specific integer
             divider.  This is the most accurate way to set the clock output
@@ -329,12 +329,16 @@ class SI5351:
             # Clock not inverted, powered up
             control |= pll.clock_control_enabled
             control |= 1 << 6  # Enable integer mode.
+            if inverted:
+                control |= 0b00010000 # Bit 4 of the control register = CLKx_INV
+            else:
+                control &= 0b11101111 # Make sure to turn it off if not inverted            
             self._si5351._write_u8(self._control, control)
             # Store the PLL and divisor value so frequency can be calculated.
             self._pll = pll
             self._divider = divider
 
-        def configure_fractional(self, pll, divider, numerator, denominator):
+        def configure_fractional(self, pll, divider, numerator, denominator, inverted=False):
             """Configure the clock output with the specified PLL source
             (should be a PLL instance on the SI5351 class) and specifiec
             fractional divider with numerator/denominator.  Again this is less
@@ -366,6 +370,10 @@ class SI5351:
             control = 0x0F  # 8mA drive strength, MS0 as CLK0 source,
             # Clock not inverted, powered up
             control |= pll.clock_control_enabled
+            if inverted:
+                control |= 0b00010000 # Bit 4 of the control register = CLKx_INV
+            else:
+                control &= 0b11101111 # Make sure to turn it off if not inverted
             self._si5351._write_u8(self._control, control)
             # Store the PLL and divisor value so frequency can be calculated.
             self._pll = pll

--- a/adafruit_si5351.py
+++ b/adafruit_si5351.py
@@ -344,6 +344,7 @@ class SI5351:
             fractional divider with numerator/denominator.  Again this is less
             accurate but has a wider range of output frequencies.
             """
+            # pylint: disable=too-many-arguments
             if divider >= 2049 or divider <= 3:
                 raise Exception("Divider must be in range 3 to 2049.")
             if denominator > 0xFFFFF or denominator <= 0:  # Prevent divide by zero.


### PR DESCRIPTION
See #26 

This adds support for inverted clock outputs, which is an easy way of obtaining a pair of 0° and 180° phase shifted signals from the same clock.

I added the parameter `inverted=False` to the two methods for configuring clocks.

So you can now create a pair of clocks like so

```
    si5351.clock_0.configure_fractional(si5351.pll_a, int_divider, numerator, denominator,
                                        inverted=False)
    si5351.clock_1.configure_fractional(si5351.pll_a, int_divider, numerator, denominator,
                                        inverted=True)
```

The default behavior is unchanged.